### PR TITLE
Fix for removed constant Image.ANTIALIAS

### DIFF
--- a/src/legend_service.py
+++ b/src/legend_service.py
@@ -140,7 +140,7 @@ class LegendService:
                         new_size = (
                             int(img.width * scale), int(img.height * scale)
                         )
-                        img = img.resize(new_size, Image.ANTIALIAS)
+                        img = img.resize(new_size, Image.LANCZOS)
                         output = BytesIO()
                         # NOTE: save as PNG to preserve any alpha channel
                         img.save(output, "PNG")


### PR DESCRIPTION
I found the following error message in our logs:

```
qwc-legend-service-1  | [2025-07-29 13:15:51,389] ERROR in legend_service: Could not resize image for stadtgrenze:
qwc-legend-service-1  | module 'PIL.Image' has no attribute 'ANTIALIAS'
```

The constant "Image.ANTIALIAS" has been removed since pillow version 10.0.0 (see https://pillow.readthedocs.io/en/stable/deprecations.html#constants).